### PR TITLE
Fixed tests on MacOS X "Mojave"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-/venv/
+*.swp
+*.pyc
+
+# build and packaging artefacts
 /coverage/
 /dist/
 /src/service.egg-info/
@@ -8,5 +11,9 @@
 /.coverage
 /test/test-*.log
 
-*.swp
-*.pyc
+# virtual environments
+/venv/
+.venv/
+
+# macos stuff
+.DS_Store

--- a/src/service/__init__.py
+++ b/src/service/__init__.py
@@ -267,16 +267,18 @@ class Service(object):
         """
         return self.pid_file.read_pid()
 
-    def set_signal(self, sig_symbol):
+    def send_signal(self, sig_symbol):
         """
-        Set an operating system signal.
+        Sends an operating system signal to the service.
 
         Returns ``True`` if the signal is configured, else ``False``
         """
         sig_num = int(sig_symbol)
         if sig_num in self.signal_state:
-            self.signal_state[sig_num].set()
-            return True
+            pid = self.get_pid()
+            if not pid:
+                raise ValueError('Daemon is not running.')
+            os.kill(pid, sig_symbol)
         else:
             return False
 
@@ -393,10 +395,7 @@ class Service(object):
         .. versionadded:: 0.3
             The ``block`` parameter
         """
-        pid = self.get_pid()
-        if not pid:
-            raise ValueError('Daemon is not running.')
-        os.kill(pid, signal.SIGTERM)
+        self.send_signal(signal.SIGTERM)
         return _block(lambda: not self.is_running(), block)
 
     def kill(self, block=False):

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -66,11 +66,31 @@ DELAY = 5
 TIMEOUT = 20
 
 
+def _is_test_deamon_process(process):
+    """
+    Test if a process is the started daemon process
+
+    On MacOS X "Mojave" (and propably some other versions), setproctitle only
+    changes the set command line argument, but not the process title itself.
+    """
+    if process.name() == NAME:
+        return True
+    elif process.name().lower().startswith("python"):
+        # MacOS X "Mojave" (and propably some other versions):
+        # Accessing the command line arguments of the process will fail
+        # drastically (segfaults) on some circumstances / processes, therefore
+        # it is first checked, if the process is a python process
+        cmd_line = process.cmdline()
+        return cmd_line and cmd_line[0] == NAME
+    else:
+        return False
+
+
 def get_processes():
     """
     Return a list of all processes of the test service.
     """
-    return [p for p in psutil.process_iter() if p.name() == NAME]
+    return [p for p in psutil.process_iter() if _is_test_deamon_process(p)]
 
 
 def kill_processes():


### PR DESCRIPTION
When using MacOS X "Mojave" (and propably other releases), setproctitle changes only the process command line argument but not the process name itself.