### PR TITLE
Enable more operation system signals than only SIGTERM. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-/venv/
+*.swp
+*.pyc
+
+# build and packaging artefacts
 /coverage/
 /dist/
 /src/service.egg-info/
@@ -8,5 +11,9 @@
 /.coverage
 /test/test-*.log
 
-*.swp
-*.pyc
+# virtual environments
+/venv/
+.venv/
+
+# macos stuff
+.DS_Store

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ The control methods are:
 * :py:meth:`~service.Service.kill` to kill the daemon
 * :py:meth:`~service.Service.is_running` to check whether the daemon is running
 * :py:meth:`~service.Service.get_pid` to get the daemon's process ID
+* :py:meth:`~service.Service.send` to send arbitrary signals to the daemon
 
 Subclasses usually do not need to override any of these.
 
@@ -101,6 +102,12 @@ When :py:meth:`~service.Service.stop` is called, the SIGTERM signal is sent to
 the daemon process, which can check for its reception using
 :py:meth:`~service.Service.got_sigterm` or wait for it using
 :py:meth:`~service.Service.wait_for_sigterm`.
+
+To use further signals to controll the daemon, these have to be specified by
+the ``custom_signals`` argument on instance creation. Custom signals can be
+sent to the daemon using :py:meth:`~service.Service.send_signal`. The daemon
+process can utilize custom signals using :py:meth:`~service.Service.got_signal`
+or :py:meth:`~service.Service.wait_for_signal`.
 
 
 Logging

--- a/src/service/__init__.py
+++ b/src/service/__init__.py
@@ -267,16 +267,18 @@ class Service(object):
         """
         return self.pid_file.read_pid()
 
-    def set_signal(self, sig_symbol):
+    def send_signal(self, sig_symbol):
         """
-        Set an operating system signal.
+        Sends an operating system signal to the service.
 
         Returns ``True`` if the signal is configured, else ``False``
         """
         sig_num = int(sig_symbol)
         if sig_num in self.signal_state:
-            self.signal_state[sig_num].set()
-            return True
+            pid = self.get_pid()
+            if not pid:
+                raise ValueError('Daemon is not running.')
+            os.kill(pid, sig_symbol)
         else:
             return False
 
@@ -393,10 +395,7 @@ class Service(object):
         .. versionadded:: 0.3
             The ``block`` parameter
         """
-        pid = self.get_pid()
-        if not pid:
-            raise ValueError('Daemon is not running.')
-        os.kill(pid, signal.SIGTERM)
+        self.send_signal(signal.SIGTERM)
         return _block(lambda: not self.is_running(), block)
 
     def kill(self, block=False):

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -66,11 +66,31 @@ DELAY = 5
 TIMEOUT = 20
 
 
+def _is_test_deamon_process(process):
+    """
+    Test if a process is the started daemon process
+
+    On MacOS X "Mojave" (and propably some other versions), setproctitle only
+    changes the set command line argument, but not the process title itself.
+    """
+    if process.name() == NAME:
+        return True
+    elif process.name().lower().startswith("python"):
+        # MacOS X "Mojave" (and propably some other versions):
+        # Accessing the command line arguments of the process will fail
+        # drastically (segfaults) on some circumstances / processes, therefore
+        # it is first checked, if the process is a python process
+        cmd_line = process.cmdline()
+        return cmd_line and cmd_line[0] == NAME
+    else:
+        return False
+
+
 def get_processes():
     """
     Return a list of all processes of the test service.
     """
-    return [p for p in psutil.process_iter() if p.name() == NAME]
+    return [p for p in psutil.process_iter() if _is_test_deamon_process(p)]
 
 
 def kill_processes():

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -143,11 +143,11 @@ class BasicService(service.Service):
     Sets the service name and uses a temporary directory for PID files
     to avoid the necessity of root privileges.
     """
-    def __init__(self, additional_signals=None):
+    def __init__(self, custom_signals=None):
         super(BasicService, self).__init__(
             NAME,
             pid_dir=PID_DIR,
-            additional_signals=additional_signals
+            custom_signals=custom_signals
         )
         formatter = logging.Formatter('%(created)f: %(message)s')
         handler = logging.FileHandler(LOG_FILE)
@@ -452,7 +452,7 @@ class TestService(object):
         class SignalService(BasicService):
             def __init__(self):
                 super(SignalService, self).__init__(
-                    additional_signals=[signal.SIGHUP]
+                    custom_signals=[signal.SIGHUP]
                 )
                 self.f = tempfile.NamedTemporaryFile(delete=False)
                 self.f.close()


### PR DESCRIPTION
This change enables daemons to respond to more operation system signals than only `SIGTERM`. An example would be to send a `SIGHUP` signal to the daemon to reload configuration files. 

The configuration of the standard signals `SIGTERM`, `SIGTTIN`, `SIGTTOU`, `SIGTSTP` is not affected by this change. The often used methods `service.Service.got_sigterm`  `service.Service.wait_for_sigterm` are still available for convenience.


An example for using a custom signal:

```python

    import signal
    from service import Service

    class MyService(Service):
        def run(self):
            while not self.got_sigterm():
                if self.got_signal(signal.SIGHUP):
                    reload_config()
                    self.clear_signal(signal.SIGHUP)
                do_work()
            

    if __name__ == '__main__':
        import sys

        if len(sys.argv) != 2:
            sys.exit('Syntax: %s COMMAND' % sys.argv[0])

        cmd = sys.argv[1].lower()
        service = MyService('my_service', pid_dir='/tmp', custom_signals=[signal.SIGHUP])

        if cmd == 'start':
            service.start()
        elif cmd == 'stop':
            service.stop()
        elif cmd == 'reload':
            service.send_signal(signal.SIGHUP)
        elif cmd == 'status':
            if service.is_running():
                print "Service is running."
            else:
                print "Service is not running."
        else:
            sys.exit('Unknown command "%s".' % cmd)
```

This pull request also includes pull request #13, since I needed to test this on my machine.