### PR TITLE
Keyword arguments passed to Service.start() are forwarded to Service.run()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-/venv/
+*.swp
+*.pyc
+
+# build and packaging artefacts
 /coverage/
 /dist/
 /src/service.egg-info/
@@ -8,5 +11,9 @@
 /.coverage
 /test/test-*.log
 
-*.swp
-*.pyc
+# virtual environments
+/venv/
+.venv/
+
+# macos stuff
+.DS_Store

--- a/src/service/__init__.py
+++ b/src/service/__init__.py
@@ -348,7 +348,7 @@ class Service(object):
         finally:
             self.pid_file.release()
 
-    def start(self, block=False):
+    def start(self, block=False, **kargs):
         """
         Start the daemon process.
 
@@ -361,6 +361,8 @@ class Service(object):
         If ``block`` is true then the call blocks until the daemon
         process has started. ``block`` can either be ``True`` (in which
         case it blocks indefinitely) or a timeout in seconds.
+
+        Other keyword arguments will be passed on to the ``run()`` method.
 
         The return value is ``True`` if the daemon process has been
         started and ``False`` otherwise.
@@ -404,7 +406,7 @@ class Service(object):
                 self.pid_file.acquire()
                 self._debug('PID file has been acquired')
                 self._debug('Calling `run`')
-                self.run()
+                self.run(**kargs)
                 self._debug('`run` returned without exception')
             except Exception as e:
                 self.logger.exception(e)
@@ -454,7 +456,7 @@ class Service(object):
         # call to ``start``.
         os._exit(os.EX_OK)
 
-    def run(self):
+    def run(self, **kargs):
         """
         Main daemon method.
 

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -66,11 +66,31 @@ DELAY = 5
 TIMEOUT = 20
 
 
+def _is_test_deamon_process(process):
+    """
+    Test if a process is the started daemon process
+
+    On MacOS X "Mojave" (and propably some other versions), setproctitle only
+    changes the set command line argument, but not the process title itself.
+    """
+    if process.name() == NAME:
+        return True
+    elif process.name().lower().startswith("python"):
+        # MacOS X "Mojave" (and propably some other versions):
+        # On accessing the command line arguments of the process will fail
+        # drastically (segfaults) on some circumstances / processes, therefore
+        # it is first checked, if the process is a python process
+        cmd_line = process.cmdline()
+        return cmd_line and cmd_line[0] == NAME
+    else:
+        return False
+
+
 def get_processes():
     """
     Return a list of all processes of the test service.
     """
-    return [p for p in psutil.process_iter() if p.name() == NAME]
+    return [p for p in psutil.process_iter() if _is_test_deamon_process(p)]
 
 
 def kill_processes():


### PR DESCRIPTION
All keyword arguments (besides `block`) are passed on to the `run()` method. This enables starting a service with a specific argument. For example this enables to pass a path to a config file only for starting the service:

```python

    from service import Service

    class MyService(Service):
        def run(self, config_file):
	    config = parse_config(config_file)
            while True:
                do_work()

    if __name__ == '__main__':
        import sys

        if 1 < len(sys.argv) <4:
            sys.exit('Syntax: %s COMMAND [config file]' % sys.argv[0])

        cmd = sys.argv[1].lower()
        service = MyService('my_service', pid_dir='/tmp')

        if cmd == 'start':
            service.start(config_file=sys.argv[2])
        elif cmd == 'stop':
            service.stop()
        elif cmd == 'status':
            if service.is_running():
                print "Service is running."
            else:
                print "Service is not running."
        else:
            sys.exit('Unknown command "%s".' % cmd)
```

This enables a nice and clean command line interface:

```sh
    python myservice.py start /path/to/config
    python myservice.py stop
    python myservice.py status
```

This pull request also includes pull request #13, since I needed to test this on my machine.